### PR TITLE
fix: Update Wazuh agent group configuration for production environment

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -121,7 +121,7 @@ wazuh:
   # Wazuh agent groups by environment
   groups:
     production:
-      - "production-servers"
+      - "servers"
       - "web-servers"
       - "database-servers"
     staging:


### PR DESCRIPTION
- Changed the group name from "production-servers" to "servers" in the Wazuh configuration file to better reflect the intended usage.